### PR TITLE
Allows context to be backwards compatible

### DIFF
--- a/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonReader.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonReader.java
@@ -740,7 +740,7 @@ public class OpenRtbJsonReader extends AbstractOpenRtbJsonReader {
         content.setVideoquality(VideoQuality.valueOf(par.getIntValue()));
         break;
       case "context":
-        content.setContext(Context.valueOf(par.getIntValue()));
+        content.setContext(Context.valueOf(par.getValueAsInt()));
         break;
       case "contentrating":
         content.setContentrating(par.getText());

--- a/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonReader.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/OpenRtbJsonReader.java
@@ -16,6 +16,7 @@
 
 package com.google.openrtb.json;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import static com.google.openrtb.json.OpenRtbJsonUtils.endArray;
 import static com.google.openrtb.json.OpenRtbJsonUtils.endObject;
 import static com.google.openrtb.json.OpenRtbJsonUtils.getCurrentName;
@@ -740,8 +741,13 @@ public class OpenRtbJsonReader extends AbstractOpenRtbJsonReader {
         content.setVideoquality(VideoQuality.valueOf(par.getIntValue()));
         break;
       case "context":
-        content.setContext(Context.valueOf(par.getValueAsInt()));
-        break;
+          try {
+              //JsonParseException may be thrown because value is string in
+              //2.2 and earlier, this allows for backwards compatibility.
+              content.setContext(Context.valueOf(par.getIntValue()));
+          } catch (JsonParseException jpe) {
+          }
+          break;
       case "contentrating":
         content.setContentrating(par.getText());
         break;


### PR DESCRIPTION
this is my first pull request so please excuse me if i have done something wrong.

context was string in 2.2 so changing to getValueAsInt fixes a parse exception.

here is an example bidrequest which failed before but works with the patch:
```json
{"site":{"id":"1000046","name":"example.com","domain":"www.example.com","page":"http://www.example.com","ref":"http://www.test.com","content":{"id":"1316436782","url":"http://www.example.com","context":"5","sourcerelationship":1}},"id":"35c441517fd44a38b953479216fd5195","tmax":70,"imp":[{"id":"ae4f2508-3bcc-4893-be78-aa9cbfa49981","instl":0,"banner":{"h":250,"w":300,"api":null}}],"device":{"os":null,"model":null,"didsha1":null,"connectiontype":3,"geo":{"country":"FRA"},"dpidsha1":null,"osv":"0","ua":"mozilla/5.0 (windows nt 6.2; wow64) applewebkit/537.17 (khtml, like gecko) chrome/24.0.1312.57 safari/537.17","devicetype":1,"language":null,"dnt":1,"make":"","ip":"109.209.108.150"},"at":2,"user":{}}
```