### PR TITLE
make CharSequenceReader public (support overload of  readBidRequest)

### DIFF
--- a/openrtb-core/src/main/java/com/google/openrtb/json/CharSequenceReader.java
+++ b/openrtb-core/src/main/java/com/google/openrtb/json/CharSequenceReader.java
@@ -30,8 +30,7 @@ import java.nio.CharBuffer;
  *
  * @author Colin Decker
  */
-// TODO(user): make this public? as a type, or a method in CharStreams?
-final class CharSequenceReader extends Reader {
+public final class CharSequenceReader extends Reader {
 
   private CharSequence seq;
   private int pos;


### PR DESCRIPTION
in order to overload readBidRequest function we need to be able to reference CharSequenceReader in our code.  