### PR TITLE
fix proto comment (user.id and user.buyeruid)

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb.proto
+++ b/openrtb-core/src/main/protobuf/openrtb.proto
@@ -1163,12 +1163,12 @@ message BidRequest {
   // privacy policies. However, this user ID must be stable long enough to serve
   // reasonably as the basis for frequency capping and retargeting.
   message User {
-    // Exchange-specific ID for the user. At least one of id or buyerid
+    // Exchange-specific ID for the user. At least one of id or buyeruid
     // is recommended.
     optional string id = 1;
 
     // Buyer-specific ID for the user as mapped by the exchange for the buyer.
-    // At least one of buyerid or id is recommended.
+    // At least one of buyeruid or id is recommended.
     optional string buyeruid = 2;
 
     // Year of birth as a 4-digit integer.


### PR DESCRIPTION
This comment is probably based on 2.3.0.

The field `buyeruid` of User was added from OpenRTB ver 2.0, but was incorrectly released as `buyerid` (not have u) in 2.3.0. This typo has been fixed as 2.3.1 release.

-- thanks for the maintenance of this proto :)