### PR TITLE
Reserve and define standard extensions

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb-ext.proto
+++ b/openrtb-core/src/main/protobuf/openrtb-ext.proto
@@ -1,0 +1,154 @@
+import "openrtb.proto";
+option java_outer_classname = "OpenRtbExt";
+package com.google.openrtb;
+
+// Ad Exchange extensions for the Regs object.
+message RegsExt {
+  // Callers should fill this field solely based on whether the impression
+  // will serve to an EEA user, based on information available to them. It
+  // does not constitute legal guidance on GDPR.
+  optional bool gdpr = 1;
+
+  // OpenRTB Extension for US Privacy (CCPA)
+  optional string us_privacy = 2;  
+}
+
+extend com.google.openrtb.BidRequest.Regs {
+  // Extension key for the Adx Regs.ext
+  optional RegsExt regs = 201;
+}
+
+message UniversalId {
+  // Cookie or platform-native identifier.
+  optional string id = 1;
+
+  // Type of user agent the match is from.  It is highly recommended to set
+  // this, as many DSPs separate app-native IDs from browser-based IDs and
+  // require a type value for ID resolution.
+  enum AgentType {
+    AGENT_TYPE_UNKNOWN = 0;
+    WEB = 1;
+    APP = 2;
+    PERSON_BASED = 3;
+  }
+  optional AgentType atype = 2;
+
+  // Extensions.
+  extensions 100 to 9999;
+}
+
+// Extended identifiers support in the OpenRTB specification allows buyers to
+// use audience data in real-time bidding.  The exchange should ensure that
+// business agreements allow for the sending of this data.  Note, it is
+// assumed that exchanges and DSPs will collaborate with the appropriate
+// regulatory agencies and ID vendor(s) to ensure compliance.
+message ExtendedId {
+  // Source or technology provider responsible for the set of included IDs.
+  // Expressed as a top-level domain.
+  optional string source = 1;
+
+  // Array of extended ID UID objects from the given source.
+  repeated UniversalId uids = 2;
+
+  // Extensions.
+  extensions 100 to 9999;
+}
+
+// Ad Exchange extensions for the User object.
+message UserExt {
+  // Consent string as specified in the IAB Transparency and Consent
+  // Framework v2.
+  optional string consent = 1;
+
+  // Extended (third-party) identifiers for this user.
+  repeated ExtendedId eids = 2;
+}
+
+extend com.google.openrtb.BidRequest.User {
+  // Extension key for the Adx User.ext
+  optional UserExt user = 202;
+}
+
+// This object represents both the links in the supply chain as well as an
+// indicator whether or not the supply chain is complete.
+message SupplyChain {
+  // Flag indicating whether the chain contains all nodes involved in the
+  // transaction leading back to the owner of the site, app or other medium of
+  // the inventory, where 0 = no, 1 = yes.
+  optional bool complete = 1;
+
+  // Version of the supply chain specification in use, in the format of
+  // “major.minor”. For example, for version 1.0 of the spec, use the string
+  // “1.0”.
+  optional string ver = 2;
+
+  // Array of SupplyChainNode objects in the order of the chain. In a complete
+  // supply chain, the first node represents the initial advertising system and
+  // seller ID involved in the transaction, i.e. the owner of the site, app, or
+  // other medium. In an incomplete supply chain, it represents the first known
+  // node. The last node represents the entity sending this bid request.
+  repeated SupplyChainNode nodes = 3;
+
+  // Extensions.
+  extensions 100 to 9999;
+}
+ 
+// This object is associated with a SupplyChain object as an array of nodes.
+// These nodes define the identity of an entity participating in the supply
+// chain of a bid request.
+message SupplyChainNode {
+  // The canonical domain name of the SSP, Exchange, Header Wrapper, etc system
+  // that bidders connect to. This may be the operational domain of the system,
+  // if that is different than the parent corporate domain, to facilitate WHOIS
+  // and reverse IP lookups to establish clear ownership of the delegate system.
+  // This should be the same value as used to identify sellers in an ads.txt
+  // file if one exists.
+  optional string asi = 1;
+
+  // The identifier associated with the seller or reseller account within the
+  // advertising system. This must contain the same value used in transactions
+  // (i.e. OpenRTB bid requests) in the field specified by the SSP/exchange.
+  // Typically, in OpenRTB, this is publisher.id. For OpenDirect it is typically
+  // the publisher’s organization ID. Should be limited to 64 characters in
+  // length.
+  optional string sid = 2;
+
+  // The OpenRTB RequestId of the request as issued by this seller.
+  optional string rid = 3;
+
+  // The name of the company (the legal entity) that is paid for inventory
+  // transacted under the given seller_id. This value is optional and should NOT
+  // be included if it exists in the advertising system’s sellers.json file.
+  optional string name = 4;
+
+  // The business domain name of the entity represented by this node. This value
+  // is optional and should NOT be included if it exists in the advertising
+  // system’s sellers.json file.
+  optional string domain = 5;
+
+  // Indicates whether this node will be involved in the flow of payment for the
+  // inventory. When set to 1, the advertising system in the asi field pays the
+  // seller in the sid field, who is responsible for paying the previous node in
+  // the chain. When set to 0, this node is not involved in the flow of payment
+  // for the inventory. For version 1.0 of SupplyChain, this property should
+  // always be 1. It is explicitly required to be included as it is expected
+  // that future versions of the specification will introduce non-payment
+  // handling nodes. Implementers should ensure that they support this field and
+  // propagate it onwards when constructing SupplyChain objects in bid requests
+  // sent to a downstream advertising system.
+  optional bool hp = 6;
+
+  // Extensions.
+  extensions 100 to 9999;
+}
+
+// Ad Exchange extensions for the Source object.
+message SourceExt {
+  optional SupplyChain schain = 1;
+}
+
+extend com.google.openrtb.BidRequest.Source {
+  // Extension key for the Adx Source.ext
+  optional SourceExt source = 202;
+}
+

--- a/openrtb-core/src/main/protobuf/openrtb.proto
+++ b/openrtb-core/src/main/protobuf/openrtb.proto
@@ -9,7 +9,8 @@ package com.google.openrtb;
 // Reserved ranges:
 //   100-199: Reserved for Google, including the openrtb-doubleclick
 //            library (DcExt) and Open Bidder project (ObExt).
-//   200-999: Free for use with other exchanges or projects.
+//   200-299: Reserved for formal standard extensions
+//   300-999: Free for use with other exchanges or projects.
 //   1000-1999: Reserved for Google.
 //   2000-9999: Free for use with other exchanges or projects.
 


### PR DESCRIPTION
I am adding the equivalent file to the IAB's copy of these definitions, and volunteer it here. There are several so-called standard extensions, and IMO it would be valuable to use the same indices for these fields across all proto implementations.