### PR TITLE
Backport connection type for 5G from AdCOM 1.0

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb.proto
+++ b/openrtb-core/src/main/protobuf/openrtb.proto
@@ -2530,6 +2530,7 @@ enum ConnectionType {
   CELL_2G = 4;
   CELL_3G = 5;
   CELL_4G = 6;
+  CELL_5G = 7;
 }
 
 // OpenRTB 2.0: The following table lists the directions in which an


### PR DESCRIPTION
This would be convenient. We see the value being used in OpenRTB 2.x JSON now.