### PR TITLE
Add standard array-of-objects field 'data' to the Content object

### DIFF
--- a/openrtb-core/src/main/protobuf/openrtb.proto
+++ b/openrtb-core/src/main/protobuf/openrtb.proto
@@ -951,6 +951,10 @@ message BidRequest {
     // Content language using ISO-639-1-alpha-2.
     optional string language = 19;
 
+    // Additional content data. Each Data object represents a different
+    // data source.
+    repeated Data data = 26;
+
     // Extensions.
     extensions 100 to 9999;
   }


### PR DESCRIPTION
This field is part of the OpenRTB standard though missing in this definition. it is important to add it so we can cement the index that gets used for it.